### PR TITLE
Fix Deadlocks

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  content: ["./**/*.html", "./**/*.templ", "./**/*.go"],
+  theme: { extend: {} },
+  plugins: [],
+};


### PR DESCRIPTION
Fixed the seemingly timed out requests.

The reason for this behavior were multiple locking attempts on the same mutex. For example in `Create(...)`:

At the start we acquire a lock and defer its release until the end of the function. Within the function body though we call `saveSessions` which itself tries to acquire a read lock on the same mutex. This leads to the situation where `RLock()` in `saveSessions` will wait for a release that will never happen, because the calling function keeps that lock. This is called a **deadlock**.

What we can do is either to only apply the lock in the parts that really need it (which this PR does) or remove the locking from `saveSessions` and expect the calling function to make sure everything is safe.

Aside: Added a very basic tailwind config file for better LSP integration when editing files in Neovim