### PR TITLE
Add live reload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+# run templ generation in watch mode to detect all .templ files and 
+# re-create _templ.txt files on change, then send reload event to browser. 
+# Default url: http://localhost:7331
+live/templ:
+	templ generate --watch --proxy="http://localhost:8080" --open-browser=false -v
+
+# run air to detect any go file changes to re-build and re-run the server.
+live/server:
+	go run github.com/cosmtrek/air@v1.51.0 \
+	--build.cmd "go build -o tmp/bin/main cmd/server/main.go" --build.bin "tmp/bin/main" --build.delay "100" \
+	--build.exclude_dir "node_modules" \
+	--build.include_ext "go" \
+	--build.stop_on_error "false" \
+	--misc.clean_on_exit true
+
+# run tailwindcss to generate the styles.css bundle in watch mode.
+# live/tailwind:
+# 	npx --yes tailwindcss -i ./input.css -o ./assets/styles.css --minify --watch
+
+# run esbuild to generate the index.js bundle in watch mode.
+# live/esbuild:
+# 	npx --yes esbuild js/index.ts --bundle --outdir=assets/ --watch
+
+# watch for any js or css change in the assets/ folder, then reload the browser via templ proxy.
+live/sync_assets:
+	go run github.com/cosmtrek/air@v1.51.0 \
+	--build.cmd "templ generate --notify-proxy" \
+	--build.bin "true" \
+	--build.delay "100" \
+	--build.exclude_dir "" \
+	--build.include_dir "assets" \
+	--build.include_ext "js,css"
+
+# start all 3 watch processes in parallel.
+live: 
+	make -j3 live/templ live/server live/tailwind live/esbuild live/sync_assets


### PR DESCRIPTION
Added a Makefile to enable live reloading of the web app and service. It implements:
- Auto-compilation of templ templates on file changes 
- Live server reload on Go file changes
- Browser auto-reload via templ proxy (http://localhost:7331)

Run with `make live`.

It's for the most part a copy of  https://templ.guide/developer-tools/live-reload-with-other-tools#putting-it-all-together

Tailwind and esbuild configurations are commented out as they're not currently needed. Strictly speaking we neither need the `sync_assets` part, but I've kept it in there because it doesn't hurt and as soon as we add js files it will _just work™_.